### PR TITLE
Path to tutorial notebooks was broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ See this [JupyterLite distribution](https://highdiceroller.github.io/icepool/not
 
 ### Tutorial notebooks
 
-In particular, here are a series of [tutorial notebooks.](https://highdiceroller.github.io/icepool/notebooks/lab?path=tutorial%2Fch00_introduction.ipynb)
+In particular, here are a series of [tutorial notebooks.](https://highdiceroller.github.io/icepool/notebooks/lab?path=tutorial%2Fc00_introduction.ipynb)
 
 ## Web applications
 


### PR DESCRIPTION
The tutorial notebooks are by far the best resource to learn to use icepool API. This fixes the broken link. 

I also belive the wording in the README should encourage people to start here.